### PR TITLE
upgrade junixsocket dependencies to fix module path problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>
             <artifactId>junixsocket-native-common</artifactId>
-            <version>2.0.4</version>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>
             <artifactId>junixsocket-common</artifactId>
-            <version>2.0.4</version>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
When trying to use this library on the module path you get:

```
[WARNING] Can't extract module name from junixsocket-native-common-2.0.4.jar: junixsocket.native.common: Invalid module name: 'native' is not a Java identifier
```

This pull request upgrades the dependencies to fix this problem, ref https://github.com/kohlschutter/junixsocket/issues/49